### PR TITLE
Fix compatibility with puppet-lint 2.2

### DIFF
--- a/lib/puppet-lint/plugins/no_erb_template.rb
+++ b/lib/puppet-lint/plugins/no_erb_template.rb
@@ -2,7 +2,7 @@ PuppetLint.new_check(:no_erb_template) do
   def check
     functions = ['template', 'inline_template']
 
-    tokens.select { |t| t.type == :NAME and functions.include? t.value }.each do |function_token|
+    tokens.select { |t| (t.type == :NAME or t.type == :FUNCTION_NAME) and functions.include? t.value }.each do |function_token|
       next unless function_token.next_code_token.type == :LPAREN
 
       key_token = function_token.next_code_token.next_code_token


### PR DESCRIPTION
puppet-lint 2.2 introduced the :FUNCTION_NAME token type, effectively
breaking the existing simple checking for :NAME.  Here we check for
either token, so the plugin will continue to work pre 2.2.